### PR TITLE
style resources

### DIFF
--- a/assets/scss/base.scss
+++ b/assets/scss/base.scss
@@ -1,7 +1,7 @@
-// h1, h2, h3, h4, h5, h6 {
-//   color: $main-text
-// }
+h1, h2, h3, h4, h5, h6 {
+  color: $main-text
+}
 
-// p {
-//   color: $thumb-text
-// }
+p {
+  color: $thumb-text
+}

--- a/assets/scss/base.scss
+++ b/assets/scss/base.scss
@@ -1,0 +1,7 @@
+// h1, h2, h3, h4, h5, h6 {
+//   color: $main-text
+// }
+
+// p {
+//   color: $thumb-text
+// }

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1,0 +1,3 @@
+@import "./variable";
+@import "./mixin";
+@import "./base";

--- a/assets/scss/mixin.scss
+++ b/assets/scss/mixin.scss
@@ -1,0 +1,5 @@
+// @mixin base {
+//   min-height: 100vh;
+//   max-width: #{$breakpoint / $base-font-size}em;
+//   margin: 0 auto;
+// }

--- a/assets/scss/variable.scss
+++ b/assets/scss/variable.scss
@@ -1,0 +1,1 @@
+$base-font-size: 16;

--- a/assets/scss/variable.scss
+++ b/assets/scss/variable.scss
@@ -1,1 +1,5 @@
 $base-font-size: 16;
+
+//color_common
+$main-text: #525252;
+$thumb-text: rgb(153, 0, 255);

--- a/assets/scss/variable.scss
+++ b/assets/scss/variable.scss
@@ -3,3 +3,7 @@ $base-font-size: 16;
 //color_common
 $main-text: #525252;
 $thumb-text: rgb(153, 0, 255);
+$mighty-action-x: #d93d8b;
+$tadoru-quest: #199ada;
+$bang-bang-shooting: #524b6f;
+$bakuso-bike: #f8e000;

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -38,7 +38,13 @@ export default {
   /*
    ** Nuxt.js modules
    */
-  modules: ['@nuxtjs/pwa'],
+  modules: ['@nuxtjs/pwa', '@nuxtjs/style-resources'],
+  /*
+   ** Style resources
+   */
+  styleResources: {
+    scss: ['./assets/scss/main.scss']
+  },
   /*
    ** Build configuration
    */

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@nuxtjs/pwa": "^3.0.0-0",
+    "@nuxtjs/style-resources": "^1.0.0",
     "nuxt": "^2.0.0"
   },
   "devDependencies": {

--- a/pages/global_test.vue
+++ b/pages/global_test.vue
@@ -1,0 +1,30 @@
+<template>
+  <div id="container">
+    <div id="exaid" class="testcase"></div>
+    <div id="brave" class="testcase"></div>
+    <div id="snipe" class="testcase"></div>
+    <div id="lazer" class="testcase"></div>
+  </div>
+</template>
+
+<script>
+export default {}
+</script>
+
+<style lang="scss">
+.testcase {
+  height: 80px;
+}
+#exaid {
+  background-color: $mighty-action-x;
+}
+#brave {
+  background-color: $tadoru-quest;
+}
+#snipe {
+  background-color: $bang-bang-shooting;
+}
+#lazer {
+  background-color: $bakuso-bike;
+}
+</style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1049,6 +1049,15 @@
     jimp-compact "^0.8.0"
     workbox-cdn "^4.3.1"
 
+"@nuxtjs/style-resources@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/style-resources/-/style-resources-1.0.0.tgz#7c4d6be19d7f7cc5d687d689f2ab16c0b94773a1"
+  integrity sha512-tDRcC/pm8B0Kpxtzb/1/HOBkv3/kPD+2FiCiUBGMB7YriRud9OUPw1pnYCsAH9ftwpMJS4k4XOyUY8FCTk6OxA==
+  dependencies:
+    consola "^2.4.0"
+    glob-all "^3.1.0"
+    sass-resources-loader "^2.0.0"
+
 "@nuxtjs/youch@^4.2.3":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@nuxtjs/youch/-/youch-4.2.3.tgz#36f8b22df5a0efaa81373109851e1d857aca6bed"
@@ -1606,6 +1615,13 @@ async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
+
+async@^2.1.4:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
+  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
+  dependencies:
+    lodash "^4.17.14"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -2378,7 +2394,7 @@ connect@^3.7.0:
     parseurl "~1.3.3"
     utils-merge "1.0.1"
 
-consola@^2.10.0, consola@^2.10.1, consola@^2.11.1, consola@^2.6.0, consola@^2.9.0:
+consola@^2.10.0, consola@^2.10.1, consola@^2.11.1, consola@^2.4.0, consola@^2.6.0, consola@^2.9.0:
   version "2.11.3"
   resolved "https://registry.yarnpkg.com/consola/-/consola-2.11.3.tgz#f7315836224c143ac5094b47fd4c816c2cd1560e"
   integrity sha512-aoW0YIIAmeftGR8GSpw6CGQluNdkWMWh3yEFjH/hmynTYnMtibXszii3lxCXmk8YxJtI3FAK5aTiquA5VH68Gw==
@@ -3925,6 +3941,14 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+glob-all@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/glob-all/-/glob-all-3.1.0.tgz#8913ddfb5ee1ac7812656241b03d5217c64b02ab"
+  integrity sha1-iRPd+17hrHgSZWJBsD1SF8ZLAqs=
+  dependencies:
+    glob "^7.0.5"
+    yargs "~1.2.6"
+
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -3940,7 +3964,7 @@ glob-parent@^5.0.0, glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -4959,7 +4983,7 @@ loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3:
+loader-utils@^1.0.2, loader-utils@^1.0.4, loader-utils@^1.1.0, loader-utils@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
   integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
@@ -5303,6 +5327,11 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
+
+minimist@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
+  integrity sha1-md9lelJXTCHJBXSX33QnkLK0wN4=
 
 minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
@@ -7351,6 +7380,16 @@ sass-loader@^8.0.2:
     schema-utils "^2.6.1"
     semver "^6.3.0"
 
+sass-resources-loader@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/sass-resources-loader/-/sass-resources-loader-2.0.1.tgz#c8427f3760bf7992f24f27d3889a1c797e971d3a"
+  integrity sha512-UsjQWm01xglINC1kPidYwKOBBzOElVupm9RwtOkRlY0hPA4GKi2KFsn4BZypRD1kudaXgUnGnfbiVOE7c+ybAg==
+  dependencies:
+    async "^2.1.4"
+    chalk "^1.1.3"
+    glob "^7.1.1"
+    loader-utils "^1.0.4"
+
 sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -8878,3 +8917,10 @@ yargs@^7.0.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
+
+yargs@~1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-1.2.6.tgz#9c7b4a82fd5d595b2bf17ab6dcc43135432fe34b"
+  integrity sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=
+  dependencies:
+    minimist "^0.1.0"


### PR DESCRIPTION
## Issue
\#8 グローバルでScssの変数を使えるようにする

## 概要
Scssで定義した変数やmixinをグローバルで使えるようにモジュールを追加する
nuxtではデフォルトではscssファイルをグローバルで読み込むことができない(はず)
なので、モジュールを使って幸せになりたい

## 変更内容
- yarnによるpackage.json、yarn.lockの更新
- nuxt.config.jsにモジュールを登録、assets/scss/main.scssをstyle-resourcesの対象に指定
- assets/scss/variables.cssにテスト用変数を追加
- テスト用ページとして、pages/global_test.vueを追加

## レビューポイント
テストが十分かどうか。