### PR TITLE
 Header

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -32,18 +32,18 @@
   line-height: 80px;
 
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   margin: 0 auto;
   padding: 0px 5%;
 
   ul {
     display: flex;
-    text-align: right;
   }
   li {
     margin-left: 50px;
     list-style-type: none;
-    letter-spacing: 8px;
+    letter-spacing: 7px;
+    display: inline-block;
   }
   a {
     color: #fff;

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -1,28 +1,21 @@
 <template>
   <header class="header-container">
-    <h1 class="header-logo">
-      <!-- <a href="/">
-        <img src="~/assets/logo-white-300x43.png" alt="AIESEC" />
-      </a> -->
-      aiesec in japan
-    </h1>
-
     <nav>
       <ul>
         <li>
-          <a href="#student">学生の方</a>
+          <a href="#about">about.</a>
         </li>
         <li>
-          <a href="#company">企業の方</a>
+          <a href="#internships">interships.</a>
         </li>
         <li>
-          <a href="#about">アイセックとは</a>
+          <a href="#activities">activities.</a>
         </li>
         <li>
-          <a href="/archive">アーカイブ</a>
+          <a href="/join">join.</a>
         </li>
         <li>
-          <a href="/press">プレスルーム</a>
+          <a href="/contact">contact.</a>
         </li>
       </ul>
     </nav>
@@ -33,7 +26,7 @@
 .header-container {
   position: fixed;
   top: 0;
-  background-color: #037ff3;
+  background-color: black;
   width: 100%;
   height: 80px;
   line-height: 80px;
@@ -45,16 +38,19 @@
 
   ul {
     display: flex;
+    text-align: right;
   }
   li {
-    margin-left: 30px;
+    margin-left: 50px;
     list-style-type: none;
+    letter-spacing: 8px;
   }
   a {
     color: #fff;
     font-weight: bold;
     text-decoration: none;
     font-size: 15px;
+    font-style: italic;
   }
   a:hover {
     opacity: 0.7;


### PR DESCRIPTION
### Issue
#1 ヘッダーを作る
### 概要
lpのヘッダーをデザインの通りに実装する
### 変更内容

- 
<img width="1440" alt="スクリーンショット 2020-02-18 午前1 17 23" src="https://user-images.githubusercontent.com/58986010/74670488-9ad4f200-51ec-11ea-95e7-8f381bdbd6ee.png">

白戸さんのデザイン案を目指しています

- フォントや行間や斜体にするところまではできたのですが、元々あった「aiesec in japan」のh1の要素を消すと、そのほかの要素が全て左詰めになってしまいます。

### レビューポイント
