### PR TITLE
Fix/header

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -12,10 +12,10 @@
           <a href="#activities">activities.</a>
         </li>
         <li>
-          <a href="/join">join.</a>
+          <a href="#join">join.</a>
         </li>
         <li>
-          <a href="/contact">contact.</a>
+          <a href="#contact">contact.</a>
         </li>
       </ul>
     </nav>
@@ -43,7 +43,6 @@
     margin-left: 35px;
     list-style-type: none;
     display: inline-block;
-    letter-spacing: 12px;
   }
   a {
     color: #fff;
@@ -51,7 +50,7 @@
     text-decoration: none;
     font-size: 15px;
     font-style: italic;
-    letter-spacing: 3px;
+    letter-spacing: 1px;
   }
   a:hover {
     opacity: 0.7;

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -32,18 +32,18 @@
   line-height: 80px;
 
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   margin: 0 auto;
   padding: 0px 5%;
 
   ul {
     display: flex;
-    text-align: right;
   }
   li {
     margin-left: 50px;
     list-style-type: none;
-    letter-spacing: 8px;
+    letter-spacing: 7px;
+    display: inline-block;
   }
   a {
     color: #fff;

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -50,7 +50,7 @@
     text-decoration: none;
     font-size: 15px;
     font-style: italic;
-    letter-spacing: 1px;
+    letter-spacing: 3px;
   }
   a:hover {
     opacity: 0.7;

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -1,28 +1,21 @@
 <template>
   <header class="header-container">
-    <h1 class="header-logo">
-      <!-- <a href="/">
-        <img src="~/assets/logo-white-300x43.png" alt="AIESEC" />
-      </a> -->
-      aiesec in japan
-    </h1>
-
     <nav>
       <ul>
         <li>
-          <a href="#student">学生の方</a>
+          <a href="#about">about.</a>
         </li>
         <li>
-          <a href="#company">企業の方</a>
+          <a href="#internships">interships.</a>
         </li>
         <li>
-          <a href="#about">アイセックとは</a>
+          <a href="#activities">activities.</a>
         </li>
         <li>
-          <a href="/archive">アーカイブ</a>
+          <a href="/join">join.</a>
         </li>
         <li>
-          <a href="/press">プレスルーム</a>
+          <a href="/contact">contact.</a>
         </li>
       </ul>
     </nav>
@@ -33,7 +26,7 @@
 .header-container {
   position: fixed;
   top: 0;
-  background-color: #037ff3;
+  background-color: black;
   width: 100%;
   height: 80px;
   line-height: 80px;
@@ -45,16 +38,19 @@
 
   ul {
     display: flex;
+    text-align: right;
   }
   li {
-    margin-left: 30px;
+    margin-left: 50px;
     list-style-type: none;
+    letter-spacing: 8px;
   }
   a {
     color: #fff;
     font-weight: bold;
     text-decoration: none;
     font-size: 15px;
+    font-style: italic;
   }
   a:hover {
     opacity: 0.7;

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -40,10 +40,10 @@
     display: flex;
   }
   li {
-    margin-left: 50px;
+    margin-left: 35px;
     list-style-type: none;
-    letter-spacing: 7px;
     display: inline-block;
+    letter-spacing: 12px;
   }
   a {
     color: #fff;
@@ -51,6 +51,7 @@
     text-decoration: none;
     font-size: 15px;
     font-style: italic;
+    letter-spacing: 3px;
   }
   a:hover {
     opacity: 0.7;


### PR DESCRIPTION
### Issue
#1 ヘッダーを作る
### 概要
lpのヘッダーをデザインの通りに実装する
### 変更内容

<img width="1440" alt="スクリーンショット 2020-02-19 午後0 43 11" src="https://user-images.githubusercontent.com/58986010/74799964-66a92080-5315-11ea-9b26-719a506fa725.png">

-ヘッダーのフォントや文字間を調整し、右詰めにしました。

- 元々あったaiesec in japanを消しました

- ナビゲーションの内容を変更しました。

 

### レビューポイント

- デザインの通りになっているか